### PR TITLE
Add basic React calendar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ laravelapp/node_modules/
 laravelapp/.env
 laravelapp/storage/
 laravelapp/bootstrap/cache/
+modernapp/node_modules/
+modernapp/dist/
+modernapp/package-lock.json

--- a/modernapp/index.html
+++ b/modernapp/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Social Calendar React</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/modernapp/package.json
+++ b/modernapp/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "modernapp",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^3.0.0"
+  }
+}

--- a/modernapp/src/App.css
+++ b/modernapp/src/App.css
@@ -1,0 +1,13 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #f4f4f4;
+  margin: 0;
+}
+.app {
+  padding: 1rem;
+  text-align: center;
+}
+.title {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}

--- a/modernapp/src/App.tsx
+++ b/modernapp/src/App.tsx
@@ -1,0 +1,11 @@
+import './App.css';
+import Calendar from './components/Calendar';
+
+export default function App() {
+  return (
+    <div className="app">
+      <h1 className="title">Social Calendar</h1>
+      <Calendar />
+    </div>
+  );
+}

--- a/modernapp/src/components/Calendar.css
+++ b/modernapp/src/components/Calendar.css
@@ -1,0 +1,32 @@
+.calendar {
+  width: 100%;
+  max-width: 700px;
+  margin: 0 auto;
+}
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.header .today {
+  margin-left: auto;
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+}
+.dow {
+  text-align: center;
+  font-weight: bold;
+}
+.day {
+  border: 1px solid #ccc;
+  min-height: 80px;
+  padding: 2px;
+}
+.day .num {
+  font-weight: bold;
+}

--- a/modernapp/src/components/Calendar.tsx
+++ b/modernapp/src/components/Calendar.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import './Calendar.css';
+
+function getMonthDays(date: Date) {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const firstDay = new Date(year, month, 1).getDay();
+  const days: (number | null)[] = [];
+  for (let i = 0; i < firstDay; i++) days.push(null);
+  for (let d = 1; d <= daysInMonth; d++) days.push(d);
+  return days;
+}
+
+export default function Calendar() {
+  const [current, setCurrent] = useState(() => new Date());
+
+  const days = getMonthDays(current);
+  const month = current.toLocaleString('default', { month: 'long' });
+  const year = current.getFullYear();
+
+  const prevMonth = () =>
+    setCurrent(new Date(current.getFullYear(), current.getMonth() - 1, 1));
+  const nextMonth = () =>
+    setCurrent(new Date(current.getFullYear(), current.getMonth() + 1, 1));
+  const goToday = () => setCurrent(new Date());
+
+  return (
+    <div className="calendar">
+      <div className="header">
+        <button onClick={prevMonth}>◀</button>
+        <span className="title">{month} {year}</span>
+        <button onClick={nextMonth}>▶</button>
+        <button onClick={goToday} className="today">Hoy</button>
+      </div>
+      <div className="grid">
+        {['Dom','Lun','Mar','Mié','Jue','Vie','Sáb'].map(d => (
+          <div key={d} className="dow">{d}</div>
+        ))}
+        {days.map((d, idx) => (
+          <div key={idx} className="day">
+            {d && <span className="num">{d}</span>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/modernapp/src/main.tsx
+++ b/modernapp/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/modernapp/tsconfig.json
+++ b/modernapp/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/modernapp/tsconfig.node.json
+++ b/modernapp/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/modernapp/vite.config.ts
+++ b/modernapp/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- ignore modernapp build artifacts
- add calendar component with month navigation
- style app and calendar

## Testing
- `npm install` within `modernapp`
- `npm run build` within `modernapp`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68415a93e724832aa8f45430a495b8b4